### PR TITLE
feat: 게시글 수정 API 및 자동저장 이미지 동기화 구현

### DIFF
--- a/src/post/dto/update-post.dto.ts
+++ b/src/post/dto/update-post.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsString,
+  MaxLength,
+  IsOptional,
+  IsIn,
+  Matches,
+  IsUrl,
+  IsObject,
+} from 'class-validator';
+import { PostStatus } from '../entities/post.entity';
+
+export class UpdatePostDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: '제목은 최대 500자까지 가능합니다' })
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: '부제목은 최대 500자까지 가능합니다' })
+  subtitle?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255, { message: 'Slug는 최대 255자까지 가능합니다' })
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    message: 'Slug는 영소문자, 숫자, 하이픈만 사용 가능합니다',
+  })
+  slug?: string;
+
+  @IsOptional()
+  @IsString()
+  content?: string; // Deprecated: 하위 호환성을 위해 유지
+
+  @IsOptional()
+  @IsObject({ message: '내용(JSON)은 객체여야 합니다' })
+  contentJson?: Record<string, any>;
+
+  @IsOptional()
+  @IsString()
+  contentHtml?: string;
+
+  @IsOptional()
+  @IsString()
+  contentText?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(Object.values(PostStatus), { message: 'status는 DRAFT 또는 PUBLISHED만 가능합니다' })
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255, { message: 'SEO 제목은 최대 255자까지 가능합니다' })
+  seoTitle?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: 'SEO 설명은 최대 500자까지 가능합니다' })
+  seoDescription?: string;
+
+  @IsOptional()
+  @IsUrl({}, { message: '유효한 URL 형식이어야 합니다' })
+  @MaxLength(500, { message: 'OG 이미지 URL은 최대 500자까지 가능합니다' })
+  ogImageUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  categoryId?: string;
+}

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Post, PostStatus } from './entities/post.entity';
 import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
 import { BusinessException } from '../common/exception/business.exception';
 import { ErrorCode } from '../common/exception/error-code';
 import { PostImageService } from '../storage/post-image.service';
@@ -134,55 +135,110 @@ export class PostService {
     const saved = await this.postRepository.save(post);
     this.logger.log(`Created post: ${saved.id} for user: ${userId}, status: ${status}`);
 
-    // ogImageUrl이 S3 URL인 경우 PostImage의 postId 연결
-    if (saved.ogImageUrl) {
-      await this.linkPostImageFromUrl(siteId, saved.id, saved.ogImageUrl);
-    }
+    // 이미지 동기화 (contentHtml + ogImageUrl의 이미지를 postId와 연결)
+    await this.syncPostImages(siteId, saved.id, saved.contentHtml, saved.ogImageUrl);
 
     return saved;
   }
 
   /**
-   * Public URL에서 s3Key 추출하여 PostImage의 post_id 연결
+   * Public URL에서 s3Key 추출
+   * @returns s3Key 또는 null (S3 URL이 아닌 경우)
    */
-  private async linkPostImageFromUrl(
+  private extractS3KeyFromUrl(imageUrl: string): string | null {
+    const baseUrl = this.s3Service.getAssetsCdnBaseUrl();
+
+    if (!imageUrl.startsWith(baseUrl)) {
+      // S3 URL이 아니면 무시 (외부 URL)
+      return null;
+    }
+
+    // s3Key 추출: baseUrl 이후 부분
+    // baseUrl이 "https://assets.pagelet-dev.kr"이고
+    // imageUrl이 "https://assets.pagelet-dev.kr/uploads/..."인 경우
+    return imageUrl.substring(baseUrl.length + 1); // +1은 슬래시 제거
+  }
+
+  /**
+   * contentHtml과 ogImageUrl에서 S3 이미지 URL 추출
+   * @returns s3Key Set
+   */
+  private extractS3KeysFromPost(
+    contentHtml: string | null,
+    ogImageUrl: string | null,
+  ): Set<string> {
+    const s3Keys = new Set<string>();
+    const baseUrl = this.s3Service.getAssetsCdnBaseUrl();
+
+    // 1. contentHtml에서 img 태그의 src 추출
+    if (contentHtml) {
+      // 정규식으로 img src 추출 (baseUrl로 시작하는 것만)
+      const imgRegex = /<img[^>]+src=["']([^"']+)["']/gi;
+      let match;
+      while ((match = imgRegex.exec(contentHtml)) !== null) {
+        const s3Key = this.extractS3KeyFromUrl(match[1]);
+        if (s3Key) {
+          s3Keys.add(s3Key);
+        }
+      }
+    }
+
+    // 2. ogImageUrl 추가
+    if (ogImageUrl) {
+      const s3Key = this.extractS3KeyFromUrl(ogImageUrl);
+      if (s3Key) {
+        s3Keys.add(s3Key);
+      }
+    }
+
+    return s3Keys;
+  }
+
+  /**
+   * 게시글 저장 시 이미지 동기화
+   * - contentHtml + ogImageUrl에 있는 이미지 → postId 연결
+   * - 기존에 연결되었지만 더 이상 사용되지 않는 이미지 → postId = null (cleanup 대상)
+   */
+  async syncPostImages(
     siteId: string,
     postId: string,
-    imageUrl: string,
+    contentHtml: string | null,
+    ogImageUrl: string | null,
   ): Promise<void> {
     try {
-      // S3 Public URL에서 s3Key 추출
-      // 예: https://assets.pagelet-dev.kr/uploads/siteId/timestamp-random.ext
-      const baseUrl = this.s3Service.getAssetsCdnBaseUrl();
+      // 1. 현재 게시글에서 사용 중인 S3 이미지 추출
+      const currentS3Keys = this.extractS3KeysFromPost(contentHtml, ogImageUrl);
 
-      if (!imageUrl.startsWith(baseUrl)) {
-        // S3 URL이 아니면 무시 (외부 URL)
-        return;
+      // 2. 기존에 이 게시글에 연결된 이미지들 조회
+      const existingImages = await this.postImageService.findByPostId(postId);
+      const existingS3Keys = new Set(existingImages.map((img) => img.s3Key));
+
+      // 3. 새로 연결해야 할 이미지 (현재 사용 중이지만 기존에 연결 안 됨)
+      for (const s3Key of currentS3Keys) {
+        if (!existingS3Keys.has(s3Key)) {
+          const linked = await this.postImageService.linkToPost(siteId, s3Key, postId);
+          if (linked) {
+            this.logger.log(`Linked s3Key ${s3Key} to post ${postId}`);
+          }
+        }
       }
 
-      // s3Key 추출: baseUrl 이후 부분
-      // baseUrl이 "https://assets.pagelet-dev.kr"이고
-      // imageUrl이 "https://assets.pagelet-dev.kr/uploads/..."인 경우
-      const s3Key = imageUrl.substring(baseUrl.length + 1); // +1은 슬래시 제거
-
-      // PostImage 조회 (postId가 null인 것)
-      const postImage = await this.postImageService.findBySiteIdAndS3Key(siteId, s3Key);
-
-      if (postImage && !postImage.postId) {
-        // postId가 null이면 연결
-        await this.postImageService.updatePostId(
-          postImage.id,
-          postId,
-          postImage.sizeBytes,
-          postImage.mimeType,
-        );
-        this.logger.log(`Linked PostImage ${postImage.id} to post ${postId}`);
+      // 4. 연결 해제해야 할 이미지 (기존에 연결되었지만 더 이상 사용 안 함)
+      for (const existingImage of existingImages) {
+        if (!currentS3Keys.has(existingImage.s3Key)) {
+          await this.postImageService.unlinkFromPost(existingImage.id);
+          this.logger.log(
+            `Unlinked s3Key ${existingImage.s3Key} from post ${postId} (cleanup target)`,
+          );
+        }
       }
-    } catch (error) {
-      // 에러가 발생해도 게시글 생성은 성공한 것으로 처리
-      this.logger.warn(
-        `Failed to link PostImage for post ${postId}, url: ${imageUrl}: ${error.message}`,
+
+      this.logger.log(
+        `Synced images for post ${postId}: ${currentS3Keys.size} images in use`,
       );
+    } catch (error) {
+      // 이미지 동기화 실패해도 게시글 저장은 성공 처리
+      this.logger.warn(`Failed to sync images for post ${postId}: ${error.message}`);
     }
   }
 
@@ -282,5 +338,64 @@ export class PostService {
       relations: ['category'],
       order: { publishedAt: 'DESC' },
     });
+  }
+
+  /**
+   * 게시글 수정
+   */
+  async updatePost(postId: string, siteId: string, dto: UpdatePostDto): Promise<Post> {
+    // 게시글 조회
+    const post = await this.postRepository.findOne({ where: { id: postId } });
+    if (!post || post.siteId !== siteId) {
+      throw BusinessException.fromErrorCode(ErrorCode.POST_NOT_FOUND);
+    }
+
+    // slug 변경 시 중복 체크
+    if (dto.slug && dto.slug !== post.slug) {
+      const isAvailable = await this.isSlugAvailable(siteId, dto.slug, postId);
+      if (!isAvailable) {
+        throw BusinessException.fromErrorCode(ErrorCode.POST_SLUG_ALREADY_EXISTS);
+      }
+    }
+
+    // categoryId 변경 시 유효성 체크
+    if (dto.categoryId && dto.categoryId !== post.categoryId) {
+      const category = await this.categoryService.findById(dto.categoryId);
+      if (!category || category.siteId !== siteId) {
+        throw BusinessException.fromErrorCode(ErrorCode.CATEGORY_NOT_FOUND);
+      }
+    }
+
+    // status 변경 처리
+    const newStatus = dto.status || post.status;
+    let publishedAt = post.publishedAt;
+
+    // DRAFT → PUBLISHED로 변경 시 publishedAt 설정
+    if (post.status === PostStatus.DRAFT && newStatus === PostStatus.PUBLISHED) {
+      publishedAt = new Date();
+    }
+
+    // 필드 업데이트 (제공된 값만)
+    if (dto.title !== undefined) post.title = dto.title;
+    if (dto.subtitle !== undefined) post.subtitle = dto.subtitle;
+    if (dto.slug !== undefined) post.slug = dto.slug;
+    if (dto.content !== undefined) post.content = dto.content;
+    if (dto.contentJson !== undefined) post.contentJson = dto.contentJson;
+    if (dto.contentHtml !== undefined) post.contentHtml = dto.contentHtml;
+    if (dto.contentText !== undefined) post.contentText = dto.contentText;
+    if (dto.status !== undefined) post.status = dto.status;
+    if (dto.seoTitle !== undefined) post.seoTitle = dto.seoTitle;
+    if (dto.seoDescription !== undefined) post.seoDescription = dto.seoDescription;
+    if (dto.ogImageUrl !== undefined) post.ogImageUrl = dto.ogImageUrl;
+    if (dto.categoryId !== undefined) post.categoryId = dto.categoryId;
+    post.publishedAt = publishedAt;
+
+    const saved = await this.postRepository.save(post);
+    this.logger.log(`Updated post: ${saved.id}, status: ${saved.status}`);
+
+    // 이미지 동기화 (contentHtml + ogImageUrl의 이미지를 postId와 연결, 제거된 이미지는 unlink)
+    await this.syncPostImages(siteId, saved.id, saved.contentHtml, saved.ogImageUrl);
+
+    return saved;
   }
 }

--- a/src/storage/storage-cleanup.service.ts
+++ b/src/storage/storage-cleanup.service.ts
@@ -15,17 +15,17 @@ export class StorageCleanupService {
   ) {}
 
   /**
-   * 매 시간마다 실행되는 Cleanup Job
-   * post_id가 null이고 48시간 이상 된 레코드 정리
-   * (게시글 저장을 하지 않은 경우를 고려하여 충분한 시간 제공)
+   * 10분마다 실행되는 Cleanup Job
+   * post_id가 null이고 30분 이상 된 레코드 정리
+   * (자동저장이 5분마다 실행되므로 30분이면 충분)
    */
-  @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_10_MINUTES)
   async cleanupOrphanedReservations() {
     this.logger.log('Starting cleanup of orphaned reservations...');
 
     try {
-      // post_id가 null이고 48시간(2880분) 이상 된 레코드 찾기
-      const orphaned = await this.postImageService.findOrphaned(2880);
+      // post_id가 null이고 30분 이상 된 레코드 찾기
+      const orphaned = await this.postImageService.findOrphaned(30);
 
       if (orphaned.length === 0) {
         this.logger.log('No orphaned reservations found');


### PR DESCRIPTION
## Summary

- 게시글 수정 API (PATCH /admin/posts/:id) 추가
- 게시글 저장 시 contentHtml과 ogImageUrl에서 이미지를 추출하여 PostImage와 연결/해제하는 동기화 로직 구현
- 자동저장 워크플로우에 맞게 이미지 cleanup 주기 조정 (10분 간격, 30분 TTL)

## Changes

### AdminPostController
- `PATCH /admin/posts/:id` 엔드포인트 추가

### PostService
- `updatePost()`: 게시글 수정 메서드 (slug/category 유효성 검사, status 변경 시 publishedAt 처리)
- `syncPostImages()`: 게시글 내 이미지 동기화 (신규 연결 + 제거된 이미지 unlink)
- `extractS3KeysFromPost()`: contentHtml + ogImageUrl에서 S3 이미지 URL 추출

### PostImageService
- `findByPostId()`: postId로 연결된 이미지 조회
- `linkToPost()`: s3Key로 이미지 찾아서 postId 연결
- `unlinkFromPost()`: postId 연결 해제 (cleanup 대상으로 전환)

### StorageCleanupService
- Cleanup 주기: 1시간 → 10분
- Orphaned 이미지 TTL: 48시간 → 30분 (자동저장이 5분마다 실행되므로 충분)

## Test plan
- [ ] 게시글 수정 API 테스트 (title, content, status 변경)
- [ ] 이미지 추가/삭제 후 저장 시 PostImage 연결 상태 확인
- [ ] DRAFT → PUBLISHED 변경 시 publishedAt 설정 확인
- [ ] slug 중복 체크 동작 확인