### PR TITLE
게시글 수정 API 및 자동저장 이미지 동기화 구현

### DIFF
--- a/src/post/admin-post.controller.ts
+++ b/src/post/admin-post.controller.ts
@@ -47,6 +47,7 @@ export class AdminPostController {
       seoTitle: post.seoTitle,
       seoDescription: post.seoDescription,
       ogImageUrl: post.ogImageUrl,
+      categoryId: post.categoryId,
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
     });
@@ -150,6 +151,7 @@ export class AdminPostController {
       seoTitle: post.seoTitle,
       seoDescription: post.seoDescription,
       ogImageUrl: post.ogImageUrl,
+      categoryId: post.categoryId,
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
     });
@@ -187,6 +189,7 @@ export class AdminPostController {
       seoTitle: post.seoTitle,
       seoDescription: post.seoDescription,
       ogImageUrl: post.ogImageUrl,
+      categoryId: post.categoryId,
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
     });

--- a/src/post/dto/post-response.dto.ts
+++ b/src/post/dto/post-response.dto.ts
@@ -14,6 +14,7 @@ export class PostResponseDto {
   seoTitle: string | null;
   seoDescription: string | null;
   ogImageUrl: string | null;
+  categoryId: string | null;
   createdAt: Date;
   updatedAt: Date;
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -233,9 +233,7 @@ export class PostService {
         }
       }
 
-      this.logger.log(
-        `Synced images for post ${postId}: ${currentS3Keys.size} images in use`,
-      );
+      this.logger.log(`Synced images for post ${postId}: ${currentS3Keys.size} images in use`);
     } catch (error) {
       // 이미지 동기화 실패해도 게시글 저장은 성공 처리
       this.logger.warn(`Failed to sync images for post ${postId}: ${error.message}`);


### PR DESCRIPTION
## 요약

- 게시글 수정 API (`PATCH /admin/posts/:id`) 추가
- 게시글 저장 시 contentHtml과 ogImageUrl에서 이미지를 추출하여 PostImage와 연결/해제하는 동기화 로직 구현
- 자동저장 워크플로우에 맞게 이미지 cleanup 주기 조정 (10분 간격, 30분 TTL)
- PostResponseDto에 categoryId 필드 추가

## 변경사항

### AdminPostController
- `PATCH /admin/posts/:id` 엔드포인트 추가
- 모든 응답에 categoryId 포함

### PostService
- `updatePost()`: 게시글 수정 메서드 (slug/category 유효성 검사, status 변경 시 publishedAt 처리)
- `syncPostImages()`: 게시글 내 이미지 동기화 (신규 연결 + 제거된 이미지 unlink)
- `extractS3KeysFromPost()`: contentHtml + ogImageUrl에서 S3 이미지 URL 추출

### PostImageService
- `findByPostId()`: postId로 연결된 이미지 조회
- `linkToPost()`: s3Key로 이미지 찾아서 postId 연결
- `unlinkFromPost()`: postId 연결 해제 (cleanup 대상으로 전환)

### StorageCleanupService
- Cleanup 주기: 1시간 → 10분
- Orphaned 이미지 TTL: 48시간 → 30분 (자동저장이 5분마다 실행되므로 충분)

### PostResponseDto
- categoryId 필드 추가

## 테스트 체크리스트
- [ ] 게시글 수정 API 테스트 (title, content, status 변경)
- [ ] 이미지 추가/삭제 후 저장 시 PostImage 연결 상태 확인
- [ ] DRAFT → PUBLISHED 변경 시 publishedAt 설정 확인
- [ ] slug 중복 체크 동작 확인
- [ ] 응답에 categoryId 포함 확인