### PR TITLE
브랜딩 에셋 업로드 API 구현 (로고, 파비콘, OG 이미지)

### DIFF
--- a/src/site/dto/site-settings-response.dto.ts
+++ b/src/site/dto/site-settings-response.dto.ts
@@ -3,6 +3,7 @@ export class SiteSettingsResponseDto {
   id: string;
   name: string;
   slug: string;
+  updatedAt: Date;
 
   // 브랜딩
   logoImageUrl: string | null;

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -110,6 +110,7 @@ export class SiteService {
       id: site.id,
       name: site.name,
       slug: site.slug,
+      updatedAt: site.updatedAt,
       logoImageUrl: site.logoImageUrl,
       faviconUrl: site.faviconUrl,
       ogImageUrl: site.ogImageUrl,

--- a/src/storage/branding-asset.controller.ts
+++ b/src/storage/branding-asset.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Post, Body, UseGuards, NotFoundException } from '@nestjs/common';
+import { BrandingAssetService } from './branding-asset.service';
+import { BrandingPresignDto } from './dto/branding-presign.dto';
+import { BrandingCommitDto } from './dto/branding-commit.dto';
+import { BrandingPresignResponseDto, BrandingCommitResponseDto } from './dto/branding-response.dto';
+import { CurrentTenant } from '../auth/decorators/current-tenant.decorator';
+import { TenantGuard } from '../auth/guards/tenant.guard';
+import { Site } from '../site/entities/site.entity';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('Branding Assets')
+@Controller('admin/assets/branding')
+@UseGuards(TenantGuard)
+export class BrandingAssetController {
+  constructor(private readonly brandingAssetService: BrandingAssetService) {}
+
+  /**
+   * POST /admin/assets/branding/presign
+   * 브랜딩 에셋 Presigned URL 생성
+   */
+  @Post('presign')
+  @ApiOperation({ summary: '브랜딩 에셋 Presigned URL 생성' })
+  @ApiResponse({
+    status: 200,
+    description: 'Presigned URL 생성 성공',
+    type: BrandingPresignResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 요청 (파일 형식/크기)' })
+  async presign(
+    @CurrentTenant() tenant: Site | null,
+    @Body() dto: BrandingPresignDto,
+  ): Promise<BrandingPresignResponseDto> {
+    if (!tenant) {
+      throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
+    }
+
+    return this.brandingAssetService.presign(tenant.id, dto);
+  }
+
+  /**
+   * POST /admin/assets/branding/commit
+   * 브랜딩 에셋 업로드 확정 (tmp → 최종 경로)
+   */
+  @Post('commit')
+  @ApiOperation({ summary: '브랜딩 에셋 업로드 확정' })
+  @ApiResponse({ status: 200, description: '업로드 확정 성공', type: BrandingCommitResponseDto })
+  @ApiResponse({ status: 404, description: '임시 파일을 찾을 수 없음' })
+  async commit(
+    @CurrentTenant() tenant: Site | null,
+    @Body() dto: BrandingCommitDto,
+  ): Promise<BrandingCommitResponseDto> {
+    if (!tenant) {
+      throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
+    }
+
+    return this.brandingAssetService.commit(tenant.id, dto);
+  }
+}

--- a/src/storage/branding-asset.service.ts
+++ b/src/storage/branding-asset.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { S3Service } from './s3.service';
+import { SiteService } from '../site/site.service';
+import { BrandingPresignDto, BrandingType } from './dto/branding-presign.dto';
+import { BrandingCommitDto } from './dto/branding-commit.dto';
+import {
+  BrandingPresignResponseDto,
+  BrandingCommitResponseDto,
+} from './dto/branding-response.dto';
+import { BusinessException } from '../common/exception/business.exception';
+import { ErrorCode } from '../common/exception/error-code';
+
+@Injectable()
+export class BrandingAssetService {
+  private readonly logger = new Logger(BrandingAssetService.name);
+
+  // 브랜딩 타입별 허용 MIME 타입
+  private readonly ALLOWED_MIME_TYPES: Record<BrandingType, string[]> = {
+    [BrandingType.LOGO]: ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'],
+    [BrandingType.FAVICON]: ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/ico'],
+    [BrandingType.OG]: ['image/png', 'image/jpeg', 'image/webp'],
+  };
+
+  // 브랜딩 타입별 최대 파일 크기 (bytes)
+  private readonly MAX_FILE_SIZE: Record<BrandingType, number> = {
+    [BrandingType.LOGO]: 2 * 1024 * 1024, // 2MB
+    [BrandingType.FAVICON]: 512 * 1024, // 512KB
+    [BrandingType.OG]: 5 * 1024 * 1024, // 5MB
+  };
+
+  constructor(
+    private readonly s3Service: S3Service,
+    private readonly siteService: SiteService,
+  ) {}
+
+  /**
+   * 브랜딩 에셋 Presigned URL 생성 (tmp 경로)
+   */
+  async presign(siteId: string, dto: BrandingPresignDto): Promise<BrandingPresignResponseDto> {
+    const { type, filename, size, mimeType } = dto;
+
+    // MIME 타입 검증
+    const allowedTypes = this.ALLOWED_MIME_TYPES[type];
+    if (!allowedTypes.includes(mimeType)) {
+      throw BusinessException.withMessage(
+        ErrorCode.UPLOAD_INVALID,
+        `지원하지 않는 파일 형식입니다. ${type === BrandingType.FAVICON ? 'PNG, ICO' : 'PNG, JPEG, WebP'}만 가능합니다`,
+      );
+    }
+
+    // 파일 크기 검증
+    const maxSize = this.MAX_FILE_SIZE[type];
+    if (size > maxSize) {
+      throw BusinessException.withMessage(
+        ErrorCode.UPLOAD_INVALID,
+        `파일 크기는 최대 ${Math.floor(maxSize / 1024)}KB까지 가능합니다`,
+      );
+    }
+
+    // 확장자 추출
+    const ext = this.s3Service.extractExtension(filename);
+
+    // tmp S3 Key 생성
+    const tmpKey = this.s3Service.generateBrandingTmpKey(siteId, type, ext);
+
+    // Presigned URL 생성 (5분 유효)
+    const uploadUrl = await this.s3Service.generatePresignedUrl(tmpKey, mimeType, 300);
+    const tmpPublicUrl = this.s3Service.getPublicUrl(tmpKey);
+
+    this.logger.log(`Generated branding presign URL for site ${siteId}, type: ${type}`);
+
+    return {
+      uploadUrl,
+      tmpPublicUrl,
+      tmpKey,
+    };
+  }
+
+  /**
+   * 브랜딩 에셋 Commit (tmp → 최종 경로 복사 + Site 업데이트)
+   */
+  async commit(siteId: string, dto: BrandingCommitDto): Promise<BrandingCommitResponseDto> {
+    const { type, tmpKey } = dto;
+
+    // tmp Key가 해당 사이트의 것인지 검증
+    if (!tmpKey.includes(`/sites/${siteId}/`)) {
+      throw BusinessException.withMessage(
+        ErrorCode.COMMON_FORBIDDEN,
+        '다른 사이트의 리소스에 접근할 수 없습니다',
+      );
+    }
+
+    // tmp 파일 존재 확인
+    try {
+      await this.s3Service.headObject(tmpKey);
+    } catch {
+      throw BusinessException.withMessage(
+        ErrorCode.UPLOAD_NOT_FOUND,
+        '임시 파일을 찾을 수 없습니다. 다시 업로드해주세요',
+      );
+    }
+
+    // 확장자 추출 (tmp key에서)
+    const ext = this.s3Service.extractExtension(tmpKey);
+
+    // 최종 S3 Key 생성
+    const finalKey = this.s3Service.generateBrandingFinalKey(siteId, type, ext);
+
+    // S3 Copy (tmp → final)
+    await this.s3Service.copyObject(tmpKey, finalKey);
+
+    // tmp 파일 삭제
+    try {
+      await this.s3Service.deleteObject(tmpKey);
+    } catch (error) {
+      this.logger.warn(`Failed to delete tmp file ${tmpKey}: ${error.message}`);
+      // tmp 삭제 실패해도 계속 진행
+    }
+
+    // Site 엔티티 업데이트
+    const publicUrl = this.s3Service.getPublicUrl(finalKey);
+    const updateData = this.getUpdateData(type, publicUrl);
+    const updatedSite = await this.siteService.updateSettings(siteId, updateData);
+
+    this.logger.log(`Committed branding asset for site ${siteId}, type: ${type}`);
+
+    return {
+      publicUrl,
+      updatedAt: updatedSite.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 브랜딩 타입에 따른 Site 업데이트 데이터 생성
+   */
+  private getUpdateData(
+    type: BrandingType,
+    publicUrl: string,
+  ): { logoImageUrl?: string; faviconUrl?: string; ogImageUrl?: string } {
+    switch (type) {
+      case BrandingType.LOGO:
+        return { logoImageUrl: publicUrl };
+      case BrandingType.FAVICON:
+        return { faviconUrl: publicUrl };
+      case BrandingType.OG:
+        return { ogImageUrl: publicUrl };
+    }
+  }
+}

--- a/src/storage/dto/branding-commit.dto.ts
+++ b/src/storage/dto/branding-commit.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { BrandingType } from './branding-presign.dto';
+
+export class BrandingCommitDto {
+  @ApiProperty({
+    description: '브랜딩 타입',
+    enum: ['logo', 'favicon', 'og'],
+    example: 'logo',
+  })
+  @IsEnum(BrandingType)
+  type: BrandingType;
+
+  @ApiProperty({
+    description: '임시 S3 Key',
+    example: 'uploads/sites/uuid/branding/tmp/logo_1234567890.png',
+  })
+  @IsString()
+  tmpKey: string;
+}

--- a/src/storage/dto/branding-presign.dto.ts
+++ b/src/storage/dto/branding-presign.dto.ts
@@ -1,0 +1,43 @@
+import { IsEnum, IsString, IsNumber, Min, Max } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export const BrandingType = {
+  LOGO: 'logo',
+  FAVICON: 'favicon',
+  OG: 'og',
+} as const;
+
+export type BrandingType = (typeof BrandingType)[keyof typeof BrandingType];
+
+export class BrandingPresignDto {
+  @ApiProperty({
+    description: '브랜딩 타입',
+    enum: ['logo', 'favicon', 'og'],
+    example: 'logo',
+  })
+  @IsEnum(BrandingType)
+  type: BrandingType;
+
+  @ApiProperty({
+    description: '원본 파일명',
+    example: 'my-logo.png',
+  })
+  @IsString()
+  filename: string;
+
+  @ApiProperty({
+    description: '파일 크기 (bytes)',
+    example: 102400,
+  })
+  @IsNumber()
+  @Min(1)
+  @Max(5 * 1024 * 1024) // 5MB
+  size: number;
+
+  @ApiProperty({
+    description: 'MIME 타입',
+    example: 'image/png',
+  })
+  @IsString()
+  mimeType: string;
+}

--- a/src/storage/dto/branding-response.dto.ts
+++ b/src/storage/dto/branding-response.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BrandingPresignResponseDto {
+  @ApiProperty({
+    description: 'Presigned URL (PUT 업로드용)',
+    example: 'https://s3.amazonaws.com/bucket/...',
+  })
+  uploadUrl: string;
+
+  @ApiProperty({
+    description: '임시 Public URL (미리보기용)',
+    example: 'https://assets.pagelet.kr/uploads/sites/uuid/branding/tmp/logo_123.png',
+  })
+  tmpPublicUrl: string;
+
+  @ApiProperty({
+    description: '임시 S3 Key (commit 시 사용)',
+    example: 'uploads/sites/uuid/branding/tmp/logo_1234567890.png',
+  })
+  tmpKey: string;
+}
+
+export class BrandingCommitResponseDto {
+  @ApiProperty({
+    description: '최종 Public URL',
+    example: 'https://assets.pagelet.kr/uploads/sites/uuid/branding/logo.png',
+  })
+  publicUrl: string;
+
+  @ApiProperty({
+    description: '업데이트 시간 (캐시 버스트용)',
+    example: '2025-01-22T10:00:00.000Z',
+  })
+  updatedAt: string;
+}

--- a/src/storage/post-image.service.ts
+++ b/src/storage/post-image.service.ts
@@ -83,6 +83,14 @@ export class PostImageService {
   }
 
   /**
+   * S3 Key 업데이트 (presign 후 실제 키 설정)
+   */
+  async updateS3Key(postImageId: string, s3Key: string): Promise<void> {
+    await this.postImageRepository.update(postImageId, { s3Key });
+    this.logger.log(`Updated PostImage ${postImageId} s3Key: ${s3Key}`);
+  }
+
+  /**
    * PostImage 삭제
    */
   async deleteByS3Key(s3Key: string): Promise<void> {

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -8,18 +8,21 @@ import { PostImageService } from './post-image.service';
 import { UploadService } from './upload.service';
 import { UploadController } from './upload.controller';
 import { StorageCleanupService } from './storage-cleanup.service';
+import { BrandingAssetService } from './branding-asset.service';
+import { BrandingAssetController } from './branding-asset.controller';
 import { SiteModule } from '../site/site.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PostImage, SiteStorageUsage]), SiteModule],
-  controllers: [UploadController],
+  controllers: [UploadController, BrandingAssetController],
   providers: [
     S3Service,
     StorageUsageService,
     PostImageService,
     UploadService,
     StorageCleanupService,
+    BrandingAssetService,
   ],
-  exports: [S3Service, StorageUsageService, PostImageService, UploadService],
+  exports: [S3Service, StorageUsageService, PostImageService, UploadService, BrandingAssetService],
 })
 export class StorageModule {}


### PR DESCRIPTION
## 요약

- 브랜딩 에셋 (로고, 파비콘, OG 이미지) 업로드를 위한 Presigned URL 및 Commit API 구현
- S3 경로 구조 개선 및 유틸리티 메서드 추가
- SiteSettingsResponseDto에 updatedAt 추가 (캐시 버스트용)

## 변경사항

### BrandingAssetController
- `POST /admin/assets/branding/presign`: Presigned URL 생성
- `POST /admin/assets/branding/commit`: 업로드 확정 (tmp → 최종 경로 이동 + Site 업데이트)

### BrandingAssetService
- 브랜딩 타입별 파일 검증
  - **로고**: PNG, JPEG, WebP, SVG (최대 2MB)
  - **파비콘**: PNG, ICO (최대 512KB)
  - **OG 이미지**: PNG, JPEG, WebP (최대 5MB)
- tmp 경로에 업로드 후 commit 시 최종 경로로 복사

### S3Service
- `generateBrandingTmpKey()`: 브랜딩 임시 경로 생성
- `generateBrandingFinalKey()`: 브랜딩 최종 경로 생성
- `generatePostImageKey()`: 게시글 이미지 새 경로 규칙
- `copyObject()`: S3 오브젝트 복사
- `extractExtension()`: 파일 확장자 추출

### S3 경로 구조
```
uploads/sites/{siteId}/
├── branding/
│   ├── tmp/         # 임시 업로드 경로
│   │   └── logo_1234567890.png
│   ├── logo.png     # 최종 경로
│   ├── favicon.ico
│   └── og.png
└── posts/{postId}/
    └── images/{imageId}.png
```

### 기타
- SiteSettingsResponseDto에 `updatedAt` 필드 추가 (브랜딩 이미지 URL에 타임스탬프 붙여서 캐시 버스트)

## 테스트 체크리스트
- [ ] 로고 이미지 업로드 (presign → PUT → commit)
- [ ] 파비콘 업로드 (ICO, PNG)
- [ ] OG 이미지 업로드
- [ ] 잘못된 파일 형식 업로드 시 에러 응답
- [ ] 파일 크기 초과 시 에러 응답
- [ ] commit 후 Site 엔티티 URL 필드 업데이트 확인