### PR TITLE
feat: 브랜딩 에셋 업로드 API 및 용어 통일 리팩토링

### DIFF
--- a/src/auth/decorators/current-site.decorator.ts
+++ b/src/auth/decorators/current-site.decorator.ts
@@ -2,18 +2,18 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Site } from '../../site/entities/site.entity';
 
 /**
- * Request에서 tenant(Site) 정보를 가져오는 데코레이터
- * TenantGuard와 함께 사용해야 함
+ * Request에서 Site 정보를 가져오는 데코레이터
+ * SiteGuard 또는 PublicSiteGuard와 함께 사용해야 함
  */
-export const CurrentTenant = createParamDecorator(
+export const CurrentSite = createParamDecorator(
   (data: keyof Site | undefined, ctx: ExecutionContext): Site[keyof Site] | Site | null => {
     const request = ctx.switchToHttp().getRequest();
-    const tenant = request.tenant as Site | null;
+    const site = request.site as Site | null;
 
-    if (!tenant) {
+    if (!site) {
       return null;
     }
 
-    return data ? tenant[data] : tenant;
+    return data ? site[data] : site;
   },
 );

--- a/src/auth/guards/public-site.guard.ts
+++ b/src/auth/guards/public-site.guard.ts
@@ -2,14 +2,14 @@ import { Injectable, CanActivate, ExecutionContext, NotFoundException } from '@n
 import { SiteService } from '../../site/site.service';
 
 /**
- * PublicTenantGuard
- * Host 헤더 기반으로 tenant(Site)를 resolve하여 request.tenant에 저장
+ * PublicSiteGuard
+ * Host 헤더 기반으로 Site를 resolve하여 request.site에 저장
  *
  * Host 형식: {slug}.pagelet-dev.kr 또는 {slug}.localhost:3000
  * 또는 X-Site-Slug 헤더로 직접 전달
  */
 @Injectable()
-export class PublicTenantGuard implements CanActivate {
+export class PublicSiteGuard implements CanActivate {
   constructor(private readonly siteService: SiteService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -33,7 +33,7 @@ export class PublicTenantGuard implements CanActivate {
       throw new NotFoundException(`사이트를 찾을 수 없습니다: ${slug}`);
     }
 
-    request.tenant = site;
+    request.site = site;
     return true;
   }
 

--- a/src/auth/guards/site.guard.ts
+++ b/src/auth/guards/site.guard.ts
@@ -2,12 +2,12 @@ import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { SiteService } from '../../site/site.service';
 
 /**
- * TenantGuard
- * 현재 로그인한 사용자의 Site를 조회하여 request.tenant에 저장
+ * SiteGuard
+ * 현재 로그인한 사용자의 Site를 조회하여 request.site에 저장
  * JwtAuthGuard 이후에 실행되어야 함
  */
 @Injectable()
-export class TenantGuard implements CanActivate {
+export class SiteGuard implements CanActivate {
   constructor(private readonly siteService: SiteService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -15,12 +15,12 @@ export class TenantGuard implements CanActivate {
     const user = request.user;
 
     if (!user?.userId) {
-      request.tenant = null;
-      return true; // Guard는 통과, tenant는 null
+      request.site = null;
+      return true; // Guard는 통과, site는 null
     }
 
     const site = await this.siteService.findByUserId(user.userId);
-    request.tenant = site;
+    request.site = site;
 
     return true;
   }

--- a/src/site/public-site-settings.controller.ts
+++ b/src/site/public-site-settings.controller.ts
@@ -1,26 +1,26 @@
 import { Controller, Get, UseGuards, Header } from '@nestjs/common';
 import { SiteService } from './site.service';
-import { PublicTenantGuard } from '../auth/guards/public-tenant.guard';
-import { CurrentTenant } from '../auth/decorators/current-tenant.decorator';
+import { PublicSiteGuard } from '../auth/guards/public-site.guard';
+import { CurrentSite } from '../auth/decorators/current-site.decorator';
 import { PublicSiteSettingsResponseDto } from './dto';
 import { Site } from './entities/site.entity';
 import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('public/site-settings')
 @Public()
-@UseGuards(PublicTenantGuard)
+@UseGuards(PublicSiteGuard)
 export class PublicSiteSettingsController {
   constructor(private readonly siteService: SiteService) {}
 
   /**
    * GET /public/site-settings
-   * Host 기반 tenant resolve 후 해당 site settings 반환
+   * Host 기반 Site resolve 후 해당 site settings 반환
    *
    * 캐싱: Cache-Control 헤더 설정 (앱단 ISR과 함께 사용)
    */
   @Get()
   @Header('Cache-Control', 'public, max-age=60, stale-while-revalidate=300')
-  async getSettings(@CurrentTenant() tenant: Site): Promise<PublicSiteSettingsResponseDto> {
-    return this.siteService.toPublicSettingsResponse(tenant);
+  async getSettings(@CurrentSite() site: Site): Promise<PublicSiteSettingsResponseDto> {
+    return this.siteService.toPublicSettingsResponse(site);
   }
 }

--- a/src/site/site-settings.controller.ts
+++ b/src/site/site-settings.controller.ts
@@ -1,42 +1,42 @@
 import { Controller, Get, Put, Body, UseGuards, NotFoundException } from '@nestjs/common';
 import { SiteService } from './site.service';
-import { CurrentTenant } from '../auth/decorators/current-tenant.decorator';
-import { TenantGuard } from '../auth/guards/tenant.guard';
+import { CurrentSite } from '../auth/decorators/current-site.decorator';
+import { SiteGuard } from '../auth/guards/site.guard';
 import { UpdateSiteSettingsDto, SiteSettingsResponseDto } from './dto';
 import { Site } from './entities/site.entity';
 
 @Controller('site-settings')
-@UseGuards(TenantGuard)
+@UseGuards(SiteGuard)
 export class SiteSettingsController {
   constructor(private readonly siteService: SiteService) {}
 
   /**
    * GET /site-settings
-   * 현재 테넌트의 사이트 설정 조회
+   * 현재 사이트 설정 조회
    * Site가 없으면 null 반환 (FE에서 생성 플로우 유도)
    */
   @Get()
   async getSettings(
-    @CurrentTenant() tenant: Site | null,
+    @CurrentSite() site: Site | null,
   ): Promise<SiteSettingsResponseDto | null> {
-    if (!tenant) {
+    if (!site) {
       return null;
     }
-    return this.siteService.toSettingsResponsePublic(tenant);
+    return this.siteService.toSettingsResponsePublic(site);
   }
 
   /**
    * PUT /site-settings
-   * 현재 테넌트의 사이트 설정 수정
+   * 현재 사이트 설정 수정
    */
   @Put()
   async updateSettings(
-    @CurrentTenant() tenant: Site | null,
+    @CurrentSite() site: Site | null,
     @Body() dto: UpdateSiteSettingsDto,
   ): Promise<SiteSettingsResponseDto> {
-    if (!tenant) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
-    return this.siteService.updateSettings(tenant.id, dto);
+    return this.siteService.updateSettings(site.id, dto);
   }
 }

--- a/src/site/site.module.ts
+++ b/src/site/site.module.ts
@@ -5,13 +5,13 @@ import { SiteSettingsController } from './site-settings.controller';
 import { PublicSiteSettingsController } from './public-site-settings.controller';
 import { SiteService } from './site.service';
 import { Site } from './entities/site.entity';
-import { TenantGuard } from '../auth/guards/tenant.guard';
-import { PublicTenantGuard } from '../auth/guards/public-tenant.guard';
+import { SiteGuard } from '../auth/guards/site.guard';
+import { PublicSiteGuard } from '../auth/guards/public-site.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Site])],
   controllers: [SiteController, SiteSettingsController, PublicSiteSettingsController],
-  providers: [SiteService, TenantGuard, PublicTenantGuard],
-  exports: [SiteService, TenantGuard, PublicTenantGuard],
+  providers: [SiteService, SiteGuard, PublicSiteGuard],
+  exports: [SiteService, SiteGuard, PublicSiteGuard],
 })
 export class SiteModule {}

--- a/src/storage/branding-asset.controller.ts
+++ b/src/storage/branding-asset.controller.ts
@@ -3,14 +3,14 @@ import { BrandingAssetService } from './branding-asset.service';
 import { BrandingPresignDto } from './dto/branding-presign.dto';
 import { BrandingCommitDto } from './dto/branding-commit.dto';
 import { BrandingPresignResponseDto, BrandingCommitResponseDto } from './dto/branding-response.dto';
-import { CurrentTenant } from '../auth/decorators/current-tenant.decorator';
-import { TenantGuard } from '../auth/guards/tenant.guard';
+import { CurrentSite } from '../auth/decorators/current-site.decorator';
+import { SiteGuard } from '../auth/guards/site.guard';
 import { Site } from '../site/entities/site.entity';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @ApiTags('Branding Assets')
 @Controller('admin/assets/branding')
-@UseGuards(TenantGuard)
+@UseGuards(SiteGuard)
 export class BrandingAssetController {
   constructor(private readonly brandingAssetService: BrandingAssetService) {}
 
@@ -27,14 +27,14 @@ export class BrandingAssetController {
   })
   @ApiResponse({ status: 400, description: '잘못된 요청 (파일 형식/크기)' })
   async presign(
-    @CurrentTenant() tenant: Site | null,
+    @CurrentSite() site: Site | null,
     @Body() dto: BrandingPresignDto,
   ): Promise<BrandingPresignResponseDto> {
-    if (!tenant) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
 
-    return this.brandingAssetService.presign(tenant.id, dto);
+    return this.brandingAssetService.presign(site.id, dto);
   }
 
   /**
@@ -46,13 +46,13 @@ export class BrandingAssetController {
   @ApiResponse({ status: 200, description: '업로드 확정 성공', type: BrandingCommitResponseDto })
   @ApiResponse({ status: 404, description: '임시 파일을 찾을 수 없음' })
   async commit(
-    @CurrentTenant() tenant: Site | null,
+    @CurrentSite() site: Site | null,
     @Body() dto: BrandingCommitDto,
   ): Promise<BrandingCommitResponseDto> {
-    if (!tenant) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
 
-    return this.brandingAssetService.commit(tenant.id, dto);
+    return this.brandingAssetService.commit(site.id, dto);
   }
 }

--- a/src/storage/upload.controller.ts
+++ b/src/storage/upload.controller.ts
@@ -3,14 +3,14 @@ import { UploadService } from './upload.service';
 import { PresignUploadDto } from './dto/presign-upload.dto';
 import { CompleteUploadDto } from './dto/complete-upload.dto';
 import { AbortUploadDto } from './dto/abort-upload.dto';
-import { CurrentTenant } from '../auth/decorators/current-tenant.decorator';
-import { TenantGuard } from '../auth/guards/tenant.guard';
+import { CurrentSite } from '../auth/decorators/current-site.decorator';
+import { SiteGuard } from '../auth/guards/site.guard';
 import { Site } from '../site/entities/site.entity';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @ApiTags('Upload')
 @Controller('uploads')
-@UseGuards(TenantGuard)
+@UseGuards(SiteGuard)
 export class UploadController {
   constructor(private readonly uploadService: UploadService) {}
 
@@ -22,12 +22,12 @@ export class UploadController {
   @ApiOperation({ summary: 'Presigned URL 생성' })
   @ApiResponse({ status: 200, description: 'Presigned URL 생성 성공' })
   @ApiResponse({ status: 400, description: '용량 초과 또는 잘못된 요청' })
-  async presign(@CurrentTenant() tenant: Site | null, @Body() dto: PresignUploadDto) {
-    if (!tenant) {
+  async presign(@CurrentSite() site: Site | null, @Body() dto: PresignUploadDto) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
 
-    return this.uploadService.presignUpload(tenant.id, dto);
+    return this.uploadService.presignUpload(site.id, dto);
   }
 
   /**
@@ -38,12 +38,12 @@ export class UploadController {
   @ApiOperation({ summary: '업로드 완료 확정' })
   @ApiResponse({ status: 200, description: '업로드 완료 확정 성공' })
   @ApiResponse({ status: 404, description: '업로드 정보를 찾을 수 없음' })
-  async complete(@CurrentTenant() tenant: Site | null, @Body() dto: CompleteUploadDto) {
-    if (!tenant) {
+  async complete(@CurrentSite() site: Site | null, @Body() dto: CompleteUploadDto) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
 
-    return this.uploadService.completeUpload(tenant.id, dto);
+    return this.uploadService.completeUpload(site.id, dto);
   }
 
   /**
@@ -53,11 +53,11 @@ export class UploadController {
   @Post('abort')
   @ApiOperation({ summary: '업로드 중단' })
   @ApiResponse({ status: 200, description: '업로드 중단 성공' })
-  async abort(@CurrentTenant() tenant: Site | null, @Body() dto: AbortUploadDto) {
-    if (!tenant) {
+  async abort(@CurrentSite() site: Site | null, @Body() dto: AbortUploadDto) {
+    if (!site) {
       throw new NotFoundException('사이트가 존재하지 않습니다. 먼저 사이트를 생성해주세요.');
     }
 
-    return this.uploadService.abortUpload(tenant.id, dto.s3Key);
+    return this.uploadService.abortUpload(site.id, dto.s3Key);
   }
 }


### PR DESCRIPTION
## Summary
- 브랜딩 에셋(로고, 파비콘, OG 이미지) 업로드 API 추가
- Presign → Commit 2단계 업로드 플로우 구현
- Tenant/Site 용어 혼용 문제 해결 (Site로 통일)

## Changes
### 브랜딩 에셋 업로드
- `POST /admin/assets/branding/presign` - Presigned URL 생성
- `POST /admin/assets/branding/commit` - 업로드 확정 및 Site 설정 반영
- 타입별 파일 형식/크기 검증 (logo: 2MB, favicon: 512KB, og: 5MB)

### 리팩토링
- `TenantGuard` → `SiteGuard`
- `PublicTenantGuard` → `PublicSiteGuard`
- `@CurrentTenant()` → `@CurrentSite()`

## Test plan
- [ ] 로고 이미지 업로드 테스트 (PNG, JPEG, WebP, SVG)
- [ ] 파비콘 업로드 테스트 (PNG, ICO)
- [ ] OG 이미지 업로드 테스트
- [ ] 파일 크기 초과 시 에러 확인
- [ ] 지원하지 않는 형식 업로드 시 에러 확인