### PR TITLE
feat: 게시글 삭제 및 PRIVATE 상태 추가

### DIFF
--- a/src/post/admin-post.controller.ts
+++ b/src/post/admin-post.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Patch, Body, Query, Param, UseGuards } from '@nestjs/common';
+import { Controller, Post, Get, Patch, Delete, Body, Query, Param, UseGuards } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -166,5 +166,18 @@ export class AdminPostController {
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
     });
+  }
+
+  /**
+   * DELETE /admin/sites/:siteId/posts/:id
+   * 게시글 삭제
+   */
+  @Delete(':id')
+  async deletePost(
+    @CurrentSite() site: Site,
+    @Param('id') postId: string,
+  ): Promise<{ success: boolean }> {
+    await this.postService.deletePost(postId, site.id);
+    return { success: true };
   }
 }

--- a/src/post/entities/post.entity.ts
+++ b/src/post/entities/post.entity.ts
@@ -15,6 +15,7 @@ import { Site } from '../../site/entities/site.entity';
 export const PostStatus = {
   DRAFT: 'DRAFT',
   PUBLISHED: 'PUBLISHED',
+  PRIVATE: 'PRIVATE', // 발행했지만 비공개
 } as const;
 
 export type PostStatus = (typeof PostStatus)[keyof typeof PostStatus];


### PR DESCRIPTION
## Summary

- PostStatus에 `PRIVATE`(비공개) 상태 추가
- 발행된 게시글을 비공개로 전환 가능 (PUBLISHED ↔ PRIVATE)
- `PostService.deletePost()` 메서드 추가
- `AdminPostController`에 `DELETE /:id` 엔드포인트 추가
- 삭제 시 연결된 이미지 cleanup 처리

## API Changes

### New Endpoint
- `DELETE /admin/sites/:siteId/posts/:id` - 게시글 삭제

### PostStatus 변경
```typescript
export const PostStatus = {
  DRAFT: 'DRAFT',
  PUBLISHED: 'PUBLISHED',
  PRIVATE: 'PRIVATE', // NEW
} as const;
```

## Test Plan

- [ ] PUBLISHED → PRIVATE 상태 변경 테스트
- [ ] PRIVATE → PUBLISHED 상태 변경 테스트
- [ ] 게시글 삭제 테스트
- [ ] Public API에서 PRIVATE 게시글 조회 불가 확인

Closes #28