### PR TITLE
[이슈 #29] 사이트 배너 기능 API 구현

### DIFF
--- a/.tasks/in-progress/29-site-banner-api.md
+++ b/.tasks/in-progress/29-site-banner-api.md
@@ -1,0 +1,300 @@
+# [BE] 사이트 배너 기능 API 구현
+
+## GitHub 이슈
+- **이슈 번호**: #29
+- **이슈 링크**: https://github.com/leehydev/pagelet-api/issues/29
+- **생성일**: 2025-01-23
+- **우선순위**: 높음
+- **관련 태스크**: leehydev/pagelet-app#35 (프론트엔드)
+
+## 개요
+
+사이트에 표시할 배너 이미지를 관리하는 API를 구현합니다.
+데스크톱/모바일 배너를 분리하여 관리하며, 시작/종료 시간 설정 및 순서 변경 기능을 제공합니다.
+
+## 작업 범위
+
+### 포함
+- site_banners 테이블 생성 (마이그레이션)
+- SiteBanner Entity 정의
+- BannerService 구현 (CRUD + 순서 변경)
+- Admin API 엔드포인트 구현
+- Public API 엔드포인트 구현
+- 파일 업로드를 위한 Presign URL 발급 API
+
+### 제외
+- 프론트엔드 UI (pagelet-app#35에서 진행)
+
+## 기술 명세
+
+### 영향받는 파일
+
+**신규 생성:**
+- `src/banner/` - 배너 모듈 디렉토리
+  - `banner.module.ts`
+  - `banner.service.ts`
+  - `admin-banner.controller.ts`
+  - `public-banner.controller.ts`
+  - `entities/site-banner.entity.ts`
+  - `dto/index.ts`
+  - `dto/banner-presign.dto.ts`
+  - `dto/create-banner.dto.ts`
+  - `dto/update-banner.dto.ts`
+  - `dto/update-banner-order.dto.ts`
+  - `dto/banner-response.dto.ts`
+  - `claude.md`
+- `src/database/migrations/1737600000000-AddSiteBannersTable.ts`
+
+**수정:**
+- `src/app.module.ts` - BannerModule import
+- `src/common/exception/error-code.ts` - ErrorCode 추가
+
+### 테이블 구조 (site_banners)
+
+```sql
+CREATE TABLE site_banners (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  image_url VARCHAR(500) NOT NULL,
+  link_url VARCHAR(500),
+  open_in_new_tab BOOLEAN DEFAULT true,
+  is_active BOOLEAN DEFAULT true,
+  start_at TIMESTAMPTZ,
+  end_at TIMESTAMPTZ,
+  display_order INT DEFAULT 0,
+  alt_text VARCHAR(255),
+  device_type VARCHAR(20) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_site_banners_site_id ON site_banners(site_id);
+CREATE INDEX idx_site_banners_device_type ON site_banners(site_id, device_type);
+```
+
+### API 엔드포인트
+
+#### Admin API
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/admin/sites/:siteId/banners/presign` | 업로드 URL 발급 |
+| POST | `/admin/sites/:siteId/banners` | 배너 생성 |
+| GET | `/admin/sites/:siteId/banners` | 배너 목록 (deviceType 쿼리) |
+| GET | `/admin/sites/:siteId/banners/:id` | 배너 상세 |
+| PUT | `/admin/sites/:siteId/banners/:id` | 배너 수정 |
+| DELETE | `/admin/sites/:siteId/banners/:id` | 배너 삭제 |
+| PUT | `/admin/sites/:siteId/banners/order` | 순서 변경 |
+
+#### Public API
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| GET | `/public/banners?siteSlug=xxx&deviceType=desktop` | 활성 배너 조회 |
+
+### 타입 정의
+
+```typescript
+// Device Type
+export const DeviceType = {
+  DESKTOP: 'desktop',
+  MOBILE: 'mobile',
+} as const;
+export type DeviceType = (typeof DeviceType)[keyof typeof DeviceType];
+
+// Entity
+@Entity('site_banners')
+export class SiteBanner {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  siteId: string;
+
+  @ManyToOne(() => Site, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'site_id' })
+  site: Site;
+
+  @Column({ type: 'varchar', length: 500 })
+  imageUrl: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  linkUrl: string | null;
+
+  @Column({ type: 'boolean', default: true })
+  openInNewTab: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  startAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  endAt: Date | null;
+
+  @Column({ type: 'int', default: 0 })
+  displayOrder: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  altText: string | null;
+
+  @Column({ type: 'varchar', length: 20 })
+  deviceType: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}
+```
+
+### DTO 정의
+
+```typescript
+// BannerPresignDto
+export class BannerPresignDto {
+  @IsString()
+  filename: string;
+
+  @IsNumber()
+  size: number;
+
+  @IsString()
+  mimeType: string;
+}
+
+// CreateBannerDto
+export class CreateBannerDto {
+  @IsString()
+  @MaxLength(500)
+  imageUrl: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  @Matches(/^https?:\/\//, { message: 'http 또는 https URL만 허용됩니다' })
+  linkUrl?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  openInNewTab?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsDateString()
+  startAt?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endAt?: string;
+
+  @IsOptional()
+  @IsNumber()
+  displayOrder?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  altText?: string;
+
+  @IsString()
+  @IsIn(['desktop', 'mobile'])
+  deviceType: string;
+}
+
+// UpdateBannerDto (모든 필드 optional)
+// UpdateBannerOrderDto
+export class UpdateBannerOrderDto {
+  @IsArray()
+  @IsUUID('4', { each: true })
+  bannerIds: string[];
+
+  @IsString()
+  @IsIn(['desktop', 'mobile'])
+  deviceType: string;
+}
+```
+
+### ErrorCode 추가
+
+```typescript
+// src/common/exception/error-code.ts
+BANNER_NOT_FOUND: new ErrorCodeDefinition(
+  'BANNER_001',
+  HttpStatus.NOT_FOUND,
+  '배너를 찾을 수 없습니다',
+),
+BANNER_LIMIT_EXCEEDED: new ErrorCodeDefinition(
+  'BANNER_002',
+  HttpStatus.BAD_REQUEST,
+  '배너는 최대 5개까지 등록할 수 있습니다',
+),
+BANNER_INVALID_LINK: new ErrorCodeDefinition(
+  'BANNER_003',
+  HttpStatus.BAD_REQUEST,
+  '유효하지 않은 링크 URL입니다',
+),
+```
+
+### 제약사항
+
+- 파일 크기: 5MB 제한
+- 권장 크기: 1280px 너비, 세로 300~500px
+- MIME: image/png, image/jpeg, image/webp
+- 사이트당 배너 최대 5개 (device_type별 각각)
+- link_url: http/https 프로토콜만 허용 (XSS 방지)
+
+## 구현 체크리스트
+
+- [ ] 마이그레이션 파일 작성 (`1737600000000-AddSiteBannersTable.ts`)
+- [ ] SiteBanner Entity 정의
+- [ ] DeviceType const object 정의
+- [ ] BannerService 구현
+  - [ ] presign() - Presign URL 발급
+  - [ ] create() - 배너 생성 (최대 5개 검증)
+  - [ ] findBySiteId() - 목록 조회
+  - [ ] findById() - 상세 조회
+  - [ ] update() - 수정
+  - [ ] delete() - 삭제
+  - [ ] updateOrder() - 순서 변경
+  - [ ] findActiveBySlug() - Public용 활성 배너 조회
+- [ ] DTO 작성
+  - [ ] BannerPresignDto
+  - [ ] CreateBannerDto
+  - [ ] UpdateBannerDto
+  - [ ] UpdateBannerOrderDto
+  - [ ] BannerResponseDto
+  - [ ] PublicBannerResponseDto
+  - [ ] BannerPresignResponseDto
+- [ ] AdminBannerController 구현
+- [ ] PublicBannerController 구현
+- [ ] BannerModule 생성 및 AppModule에 등록
+- [ ] ErrorCode 추가
+- [ ] claude.md 문서 작성
+- [ ] npm run build 성공
+- [ ] npm run lint 통과
+- [ ] npm run test 통과
+
+## 테스트 계획
+
+- [ ] 배너 생성 API 테스트
+- [ ] 배너 목록 조회 테스트 (deviceType 필터)
+- [ ] 배너 수정 API 테스트
+- [ ] 배너 삭제 API 테스트
+- [ ] 순서 변경 API 테스트
+- [ ] Public API 필터링 테스트 (활성/기간 조건)
+- [ ] 파일 업로드 presign 테스트
+- [ ] 최대 5개 제한 테스트
+- [ ] 권한 검증 테스트 (AdminSiteGuard)
+
+## 참고 자료
+
+- 기존 BrandingAssetService 패턴: `src/storage/branding-asset.service.ts`
+- AdminCategoryController 구조: `src/category/admin-category.controller.ts`
+- PublicPostController siteSlug 쿼리 파라미터 패턴: `src/post/public-post.controller.ts`
+- S3Service presign 메서드: `src/storage/s3.service.ts`

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { User } from './auth/entities/user.entity';
 import { PostModule } from './post/post.module';
 import { StorageModule } from './storage/storage.module';
 import { CategoryModule } from './category/category.module';
+import { BannerModule } from './banner/banner.module';
 import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
@@ -32,6 +33,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     PostModule,
     CategoryModule,
     StorageModule,
+    BannerModule,
     ScheduleModule.forRoot(),
     TypeOrmModule.forFeature([User]), // AccountStatusGuard에서 User Repository 사용
   ],

--- a/src/banner/CLAUDE.md
+++ b/src/banner/CLAUDE.md
@@ -1,0 +1,75 @@
+# Banner 모듈
+
+사이트 배너 이미지 관리를 담당합니다.
+
+## 주요 구성요소
+
+### Entity
+
+- `SiteBanner` - 배너 (imageUrl, linkUrl, deviceType, displayOrder 등)
+
+### 디바이스 타입
+
+```typescript
+DeviceType.DESKTOP  // 데스크톱 배너
+DeviceType.MOBILE   // 모바일 배너
+```
+
+### 주요 필드
+
+```typescript
+siteId: string          // 소속 사이트
+imageUrl: string        // 배너 이미지 URL
+linkUrl: string | null  // 클릭 시 이동 URL
+openInNewTab: boolean   // 새 탭에서 열기
+isActive: boolean       // 활성화 상태
+startAt: Date | null    // 노출 시작 시간
+endAt: Date | null      // 노출 종료 시간
+displayOrder: number    // 표시 순서
+altText: string | null  // 대체 텍스트
+deviceType: string      // 디바이스 타입 (desktop/mobile)
+```
+
+## Controllers
+
+### AdminBannerController
+
+```
+POST   /admin/sites/:siteId/banners/presign  - 이미지 업로드 URL 발급
+POST   /admin/sites/:siteId/banners          - 배너 생성
+GET    /admin/sites/:siteId/banners          - 배너 목록 (deviceType 필터)
+GET    /admin/sites/:siteId/banners/:id      - 배너 상세
+PUT    /admin/sites/:siteId/banners/:id      - 배너 수정
+DELETE /admin/sites/:siteId/banners/:id      - 배너 삭제
+PUT    /admin/sites/:siteId/banners/order    - 순서 변경
+```
+
+### PublicBannerController
+
+```
+GET /public/banners?siteSlug=xxx&deviceType=desktop  - 활성 배너 조회
+```
+
+## 관계
+
+- `SiteBanner` -> `Site` (N:1)
+
+## 제약사항
+
+- 디바이스 타입별 배너 최대 5개
+- 파일 크기: 5MB 제한
+- 허용 MIME: image/png, image/jpeg, image/webp
+- linkUrl: http/https 프로토콜만 허용
+
+## Public API 필터링
+
+활성 배너 조회 시 다음 조건이 적용됩니다:
+- `isActive = true`
+- `startAt IS NULL OR startAt <= now()`
+- `endAt IS NULL OR endAt >= now()`
+
+## 주의사항
+
+- displayOrder가 지정되지 않으면 자동으로 마지막 순서 + 1
+- 삭제 시 Site 삭제와 함께 CASCADE 삭제됨
+- 순서 변경 시 해당 deviceType의 모든 배너가 재정렬됨

--- a/src/banner/admin-banner.controller.ts
+++ b/src/banner/admin-banner.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { BannerService } from './banner.service';
+import {
+  BannerPresignDto,
+  BannerPresignResponseDto,
+  CreateBannerDto,
+  UpdateBannerDto,
+  UpdateBannerOrderDto,
+  BannerResponseDto,
+} from './dto';
+import { CurrentSite } from '../auth/decorators/current-site.decorator';
+import { AdminSiteGuard } from '../auth/guards/admin-site.guard';
+import { Site } from '../site/entities/site.entity';
+import { BusinessException } from '../common/exception/business.exception';
+import { ErrorCode } from '../common/exception/error-code';
+
+@Controller('admin/sites/:siteId/banners')
+@UseGuards(AdminSiteGuard)
+export class AdminBannerController {
+  constructor(private readonly bannerService: BannerService) {}
+
+  /**
+   * POST /admin/sites/:siteId/banners/presign
+   * 배너 이미지 업로드 URL 발급
+   */
+  @Post('presign')
+  async presign(
+    @CurrentSite() site: Site,
+    @Body() dto: BannerPresignDto,
+  ): Promise<BannerPresignResponseDto> {
+    return this.bannerService.presign(site.id, dto);
+  }
+
+  /**
+   * POST /admin/sites/:siteId/banners
+   * 배너 생성
+   */
+  @Post()
+  async createBanner(
+    @CurrentSite() site: Site,
+    @Body() dto: CreateBannerDto,
+  ): Promise<BannerResponseDto> {
+    const banner = await this.bannerService.create(site.id, dto);
+    return this.bannerService.toBannerResponse(banner);
+  }
+
+  /**
+   * GET /admin/sites/:siteId/banners
+   * 배너 목록 조회 (deviceType 쿼리 파라미터로 필터링)
+   */
+  @Get()
+  async getBanners(
+    @CurrentSite() site: Site,
+    @Query('deviceType') deviceType?: string,
+  ): Promise<BannerResponseDto[]> {
+    const banners = await this.bannerService.findBySiteId(site.id, deviceType);
+    return banners.map((banner) => this.bannerService.toBannerResponse(banner));
+  }
+
+  /**
+   * GET /admin/sites/:siteId/banners/:id
+   * 배너 상세 조회
+   */
+  @Get(':id')
+  async getBanner(
+    @CurrentSite() site: Site,
+    @Param('id') bannerId: string,
+  ): Promise<BannerResponseDto> {
+    const banner = await this.bannerService.findById(bannerId);
+    if (!banner || banner.siteId !== site.id) {
+      throw BusinessException.fromErrorCode(ErrorCode.BANNER_NOT_FOUND);
+    }
+    return this.bannerService.toBannerResponse(banner);
+  }
+
+  /**
+   * PUT /admin/sites/:siteId/banners/:id
+   * 배너 수정
+   */
+  @Put(':id')
+  async updateBanner(
+    @CurrentSite() site: Site,
+    @Param('id') bannerId: string,
+    @Body() dto: UpdateBannerDto,
+  ): Promise<BannerResponseDto> {
+    const banner = await this.bannerService.update(bannerId, site.id, dto);
+    return this.bannerService.toBannerResponse(banner);
+  }
+
+  /**
+   * DELETE /admin/sites/:siteId/banners/:id
+   * 배너 삭제
+   */
+  @Delete(':id')
+  async deleteBanner(@CurrentSite() site: Site, @Param('id') bannerId: string): Promise<void> {
+    await this.bannerService.delete(bannerId, site.id);
+  }
+
+  /**
+   * PUT /admin/sites/:siteId/banners/order
+   * 배너 순서 변경
+   */
+  @Put('order')
+  async updateOrder(
+    @CurrentSite() site: Site,
+    @Body() dto: UpdateBannerOrderDto,
+  ): Promise<BannerResponseDto[]> {
+    const banners = await this.bannerService.updateOrder(site.id, dto);
+    return banners.map((banner) => this.bannerService.toBannerResponse(banner));
+  }
+}

--- a/src/banner/banner.module.ts
+++ b/src/banner/banner.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SiteBanner } from './entities/site-banner.entity';
+import { BannerService } from './banner.service';
+import { AdminBannerController } from './admin-banner.controller';
+import { PublicBannerController } from './public-banner.controller';
+import { SiteModule } from '../site/site.module';
+import { StorageModule } from '../storage/storage.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SiteBanner]), SiteModule, StorageModule],
+  controllers: [AdminBannerController, PublicBannerController],
+  providers: [BannerService],
+  exports: [BannerService],
+})
+export class BannerModule {}

--- a/src/banner/banner.service.ts
+++ b/src/banner/banner.service.ts
@@ -1,0 +1,287 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In, LessThanOrEqual, MoreThanOrEqual, IsNull, Or } from 'typeorm';
+import { SiteBanner } from './entities/site-banner.entity';
+import { S3Service } from '../storage/s3.service';
+import { SiteService } from '../site/site.service';
+import { BusinessException } from '../common/exception/business.exception';
+import { ErrorCode } from '../common/exception/error-code';
+import {
+  BannerPresignDto,
+  BannerPresignResponseDto,
+  CreateBannerDto,
+  UpdateBannerDto,
+  UpdateBannerOrderDto,
+  BannerResponseDto,
+  PublicBannerResponseDto,
+} from './dto';
+
+// 배너 관련 상수
+const MAX_BANNERS_PER_DEVICE = 5;
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+@Injectable()
+export class BannerService {
+  private readonly logger = new Logger(BannerService.name);
+
+  constructor(
+    @InjectRepository(SiteBanner)
+    private readonly bannerRepository: Repository<SiteBanner>,
+    private readonly s3Service: S3Service,
+    private readonly siteService: SiteService,
+  ) {}
+
+  /**
+   * 배너 이미지 Presigned URL 발급
+   */
+  async presign(siteId: string, dto: BannerPresignDto): Promise<BannerPresignResponseDto> {
+    const { filename, size, mimeType } = dto;
+
+    // MIME 타입 검증
+    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.UPLOAD_INVALID,
+        '지원하지 않는 파일 형식입니다. PNG, JPEG, WebP만 가능합니다',
+      );
+    }
+
+    // 파일 크기 검증
+    if (size > MAX_FILE_SIZE) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.UPLOAD_INVALID,
+        '파일 크기는 최대 5MB까지 가능합니다',
+      );
+    }
+
+    // 확장자 추출
+    const ext = this.s3Service.extractExtension(filename);
+
+    // S3 Key 생성
+    const timestamp = Date.now();
+    const random = Math.random().toString(36).substring(2, 15);
+    const s3Key = `uploads/sites/${siteId}/banners/${timestamp}-${random}.${ext}`;
+
+    // Presigned URL 생성 (5분 유효)
+    const uploadUrl = await this.s3Service.generatePresignedUrl(s3Key, mimeType, 300);
+    const publicUrl = this.s3Service.getPublicUrl(s3Key);
+
+    this.logger.log(`Generated banner presign URL for site ${siteId}`);
+
+    return new BannerPresignResponseDto({
+      uploadUrl,
+      publicUrl,
+    });
+  }
+
+  /**
+   * 배너 생성
+   */
+  async create(siteId: string, dto: CreateBannerDto): Promise<SiteBanner> {
+    // 동일 deviceType 배너 수 제한 검증
+    const existingCount = await this.bannerRepository.count({
+      where: { siteId, deviceType: dto.deviceType },
+    });
+
+    if (existingCount >= MAX_BANNERS_PER_DEVICE) {
+      throw BusinessException.fromErrorCode(ErrorCode.BANNER_LIMIT_EXCEEDED);
+    }
+
+    // displayOrder가 제공되지 않으면 마지막 순서 + 1
+    let displayOrder = dto.displayOrder;
+    if (displayOrder === undefined) {
+      const lastBanner = await this.bannerRepository.findOne({
+        where: { siteId, deviceType: dto.deviceType },
+        order: { displayOrder: 'DESC' },
+      });
+      displayOrder = lastBanner ? lastBanner.displayOrder + 1 : 0;
+    }
+
+    const banner = this.bannerRepository.create({
+      siteId,
+      imageUrl: dto.imageUrl,
+      linkUrl: dto.linkUrl || null,
+      openInNewTab: dto.openInNewTab ?? true,
+      isActive: dto.isActive ?? true,
+      startAt: dto.startAt ? new Date(dto.startAt) : null,
+      endAt: dto.endAt ? new Date(dto.endAt) : null,
+      displayOrder,
+      altText: dto.altText || null,
+      deviceType: dto.deviceType,
+    });
+
+    const saved = await this.bannerRepository.save(banner);
+    this.logger.log(`Created banner: ${saved.id} for site: ${siteId}`);
+    return saved;
+  }
+
+  /**
+   * 사이트의 배너 목록 조회 (Admin용)
+   */
+  async findBySiteId(siteId: string, deviceType?: string): Promise<SiteBanner[]> {
+    const where: { siteId: string; deviceType?: string } = { siteId };
+    if (deviceType) {
+      where.deviceType = deviceType;
+    }
+
+    return this.bannerRepository.find({
+      where,
+      order: { deviceType: 'ASC', displayOrder: 'ASC', createdAt: 'ASC' },
+    });
+  }
+
+  /**
+   * 배너 ID로 조회
+   */
+  async findById(bannerId: string): Promise<SiteBanner | null> {
+    return this.bannerRepository.findOne({ where: { id: bannerId } });
+  }
+
+  /**
+   * 배너 수정
+   */
+  async update(bannerId: string, siteId: string, dto: UpdateBannerDto): Promise<SiteBanner> {
+    const banner = await this.findById(bannerId);
+    if (!banner) {
+      throw BusinessException.fromErrorCode(ErrorCode.BANNER_NOT_FOUND);
+    }
+
+    // 다른 사이트의 배너는 수정 불가
+    if (banner.siteId !== siteId) {
+      throw BusinessException.fromErrorCode(ErrorCode.COMMON_FORBIDDEN);
+    }
+
+    // 필드별 업데이트
+    if (dto.imageUrl !== undefined) banner.imageUrl = dto.imageUrl;
+    if (dto.linkUrl !== undefined) banner.linkUrl = dto.linkUrl;
+    if (dto.openInNewTab !== undefined) banner.openInNewTab = dto.openInNewTab;
+    if (dto.isActive !== undefined) banner.isActive = dto.isActive;
+    if (dto.startAt !== undefined) banner.startAt = dto.startAt ? new Date(dto.startAt) : null;
+    if (dto.endAt !== undefined) banner.endAt = dto.endAt ? new Date(dto.endAt) : null;
+    if (dto.displayOrder !== undefined) banner.displayOrder = dto.displayOrder;
+    if (dto.altText !== undefined) banner.altText = dto.altText;
+
+    const updated = await this.bannerRepository.save(banner);
+    this.logger.log(`Updated banner: ${updated.id}`);
+    return updated;
+  }
+
+  /**
+   * 배너 삭제
+   */
+  async delete(bannerId: string, siteId: string): Promise<void> {
+    const banner = await this.findById(bannerId);
+    if (!banner) {
+      throw BusinessException.fromErrorCode(ErrorCode.BANNER_NOT_FOUND);
+    }
+
+    // 다른 사이트의 배너는 삭제 불가
+    if (banner.siteId !== siteId) {
+      throw BusinessException.fromErrorCode(ErrorCode.COMMON_FORBIDDEN);
+    }
+
+    await this.bannerRepository.remove(banner);
+    this.logger.log(`Deleted banner: ${bannerId}`);
+  }
+
+  /**
+   * 배너 순서 변경
+   */
+  async updateOrder(siteId: string, dto: UpdateBannerOrderDto): Promise<SiteBanner[]> {
+    const { bannerIds, deviceType } = dto;
+
+    // 해당 deviceType의 모든 배너 조회
+    const banners = await this.bannerRepository.find({
+      where: { siteId, deviceType, id: In(bannerIds) },
+    });
+
+    // 모든 배너가 존재하는지 검증
+    if (banners.length !== bannerIds.length) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.BANNER_NOT_FOUND,
+        '일부 배너를 찾을 수 없습니다',
+      );
+    }
+
+    // 순서 업데이트
+    const bannerMap = new Map(banners.map((b) => [b.id, b]));
+    const updatedBanners: SiteBanner[] = [];
+
+    for (let i = 0; i < bannerIds.length; i++) {
+      const banner = bannerMap.get(bannerIds[i]);
+      if (banner) {
+        banner.displayOrder = i;
+        updatedBanners.push(banner);
+      }
+    }
+
+    await this.bannerRepository.save(updatedBanners);
+    this.logger.log(`Updated banner order for site: ${siteId}, deviceType: ${deviceType}`);
+
+    return this.findBySiteId(siteId, deviceType);
+  }
+
+  /**
+   * 공개 배너 조회 (Public API용)
+   * - isActive가 true
+   * - 현재 시간이 startAt ~ endAt 범위 내
+   */
+  async findActiveBySlug(siteSlug: string, deviceType: string): Promise<SiteBanner[]> {
+    // siteSlug로 사이트 조회
+    const site = await this.siteService.findBySlug(siteSlug);
+    if (!site) {
+      throw BusinessException.fromErrorCode(ErrorCode.SITE_NOT_FOUND);
+    }
+
+    const now = new Date();
+
+    // QueryBuilder를 사용하여 복잡한 조건 처리
+    const banners = await this.bannerRepository
+      .createQueryBuilder('banner')
+      .where('banner.siteId = :siteId', { siteId: site.id })
+      .andWhere('banner.deviceType = :deviceType', { deviceType })
+      .andWhere('banner.isActive = :isActive', { isActive: true })
+      .andWhere('(banner.startAt IS NULL OR banner.startAt <= :now)', { now })
+      .andWhere('(banner.endAt IS NULL OR banner.endAt >= :now)', { now })
+      .orderBy('banner.displayOrder', 'ASC')
+      .addOrderBy('banner.createdAt', 'ASC')
+      .getMany();
+
+    return banners;
+  }
+
+  /**
+   * Entity를 BannerResponseDto로 변환
+   */
+  toBannerResponse(banner: SiteBanner): BannerResponseDto {
+    return new BannerResponseDto({
+      id: banner.id,
+      siteId: banner.siteId,
+      imageUrl: banner.imageUrl,
+      linkUrl: banner.linkUrl,
+      openInNewTab: banner.openInNewTab,
+      isActive: banner.isActive,
+      startAt: banner.startAt,
+      endAt: banner.endAt,
+      displayOrder: banner.displayOrder,
+      altText: banner.altText,
+      deviceType: banner.deviceType,
+      createdAt: banner.createdAt,
+      updatedAt: banner.updatedAt,
+    });
+  }
+
+  /**
+   * Entity를 PublicBannerResponseDto로 변환
+   */
+  toPublicBannerResponse(banner: SiteBanner): PublicBannerResponseDto {
+    return new PublicBannerResponseDto({
+      id: banner.id,
+      imageUrl: banner.imageUrl,
+      linkUrl: banner.linkUrl,
+      openInNewTab: banner.openInNewTab,
+      altText: banner.altText,
+      displayOrder: banner.displayOrder,
+    });
+  }
+}

--- a/src/banner/dto/banner-presign.dto.ts
+++ b/src/banner/dto/banner-presign.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsNumber, Min, Max } from 'class-validator';
+
+export class BannerPresignDto {
+  @IsString({ message: '파일명은 문자열이어야 합니다' })
+  filename: string;
+
+  @IsNumber({}, { message: '파일 크기는 숫자여야 합니다' })
+  @Min(1, { message: '파일 크기는 1바이트 이상이어야 합니다' })
+  @Max(5 * 1024 * 1024, { message: '파일 크기는 최대 5MB까지 가능합니다' })
+  size: number;
+
+  @IsString({ message: 'MIME 타입은 문자열이어야 합니다' })
+  mimeType: string;
+}
+
+export class BannerPresignResponseDto {
+  uploadUrl: string;
+  publicUrl: string;
+
+  constructor(partial: Partial<BannerPresignResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/banner/dto/banner-response.dto.ts
+++ b/src/banner/dto/banner-response.dto.ts
@@ -1,0 +1,32 @@
+export class BannerResponseDto {
+  id: string;
+  siteId: string;
+  imageUrl: string;
+  linkUrl: string | null;
+  openInNewTab: boolean;
+  isActive: boolean;
+  startAt: Date | null;
+  endAt: Date | null;
+  displayOrder: number;
+  altText: string | null;
+  deviceType: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(partial: Partial<BannerResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+export class PublicBannerResponseDto {
+  id: string;
+  imageUrl: string;
+  linkUrl: string | null;
+  openInNewTab: boolean;
+  altText: string | null;
+  displayOrder: number;
+
+  constructor(partial: Partial<PublicBannerResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/banner/dto/create-banner.dto.ts
+++ b/src/banner/dto/create-banner.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsDateString,
+  IsNumber,
+  IsIn,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+export class CreateBannerDto {
+  @IsString({ message: '이미지 URL은 문자열이어야 합니다' })
+  @MaxLength(500, { message: '이미지 URL은 최대 500자까지 가능합니다' })
+  imageUrl: string;
+
+  @IsOptional()
+  @IsString({ message: '링크 URL은 문자열이어야 합니다' })
+  @MaxLength(500, { message: '링크 URL은 최대 500자까지 가능합니다' })
+  @Matches(/^https?:\/\//, { message: 'http 또는 https URL만 허용됩니다' })
+  linkUrl?: string;
+
+  @IsOptional()
+  @IsBoolean({ message: '새 탭에서 열기 값은 불리언이어야 합니다' })
+  openInNewTab?: boolean;
+
+  @IsOptional()
+  @IsBoolean({ message: '활성화 값은 불리언이어야 합니다' })
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsDateString({}, { message: '시작 시간은 ISO 8601 형식이어야 합니다' })
+  startAt?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: '종료 시간은 ISO 8601 형식이어야 합니다' })
+  endAt?: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: '표시 순서는 숫자여야 합니다' })
+  displayOrder?: number;
+
+  @IsOptional()
+  @IsString({ message: '대체 텍스트는 문자열이어야 합니다' })
+  @MaxLength(255, { message: '대체 텍스트는 최대 255자까지 가능합니다' })
+  altText?: string;
+
+  @IsString({ message: '디바이스 타입은 문자열이어야 합니다' })
+  @IsIn(['desktop', 'mobile'], { message: '디바이스 타입은 desktop 또는 mobile이어야 합니다' })
+  deviceType: string;
+}

--- a/src/banner/dto/index.ts
+++ b/src/banner/dto/index.ts
@@ -1,0 +1,5 @@
+export * from './banner-presign.dto';
+export * from './create-banner.dto';
+export * from './update-banner.dto';
+export * from './update-banner-order.dto';
+export * from './banner-response.dto';

--- a/src/banner/dto/update-banner-order.dto.ts
+++ b/src/banner/dto/update-banner-order.dto.ts
@@ -1,0 +1,11 @@
+import { IsArray, IsUUID, IsString, IsIn } from 'class-validator';
+
+export class UpdateBannerOrderDto {
+  @IsArray({ message: '배너 ID 목록은 배열이어야 합니다' })
+  @IsUUID('4', { each: true, message: '각 배너 ID는 유효한 UUID여야 합니다' })
+  bannerIds: string[];
+
+  @IsString({ message: '디바이스 타입은 문자열이어야 합니다' })
+  @IsIn(['desktop', 'mobile'], { message: '디바이스 타입은 desktop 또는 mobile이어야 합니다' })
+  deviceType: string;
+}

--- a/src/banner/dto/update-banner.dto.ts
+++ b/src/banner/dto/update-banner.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsDateString,
+  IsNumber,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+export class UpdateBannerDto {
+  @IsOptional()
+  @IsString({ message: '이미지 URL은 문자열이어야 합니다' })
+  @MaxLength(500, { message: '이미지 URL은 최대 500자까지 가능합니다' })
+  imageUrl?: string;
+
+  @IsOptional()
+  @IsString({ message: '링크 URL은 문자열이어야 합니다' })
+  @MaxLength(500, { message: '링크 URL은 최대 500자까지 가능합니다' })
+  @Matches(/^https?:\/\//, { message: 'http 또는 https URL만 허용됩니다' })
+  linkUrl?: string | null;
+
+  @IsOptional()
+  @IsBoolean({ message: '새 탭에서 열기 값은 불리언이어야 합니다' })
+  openInNewTab?: boolean;
+
+  @IsOptional()
+  @IsBoolean({ message: '활성화 값은 불리언이어야 합니다' })
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsDateString({}, { message: '시작 시간은 ISO 8601 형식이어야 합니다' })
+  startAt?: string | null;
+
+  @IsOptional()
+  @IsDateString({}, { message: '종료 시간은 ISO 8601 형식이어야 합니다' })
+  endAt?: string | null;
+
+  @IsOptional()
+  @IsNumber({}, { message: '표시 순서는 숫자여야 합니다' })
+  displayOrder?: number;
+
+  @IsOptional()
+  @IsString({ message: '대체 텍스트는 문자열이어야 합니다' })
+  @MaxLength(255, { message: '대체 텍스트는 최대 255자까지 가능합니다' })
+  altText?: string | null;
+}

--- a/src/banner/entities/site-banner.entity.ts
+++ b/src/banner/entities/site-banner.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Site } from '../../site/entities/site.entity';
+
+// Device Type (DB enum 대신 const object 사용)
+export const DeviceType = {
+  DESKTOP: 'desktop',
+  MOBILE: 'mobile',
+} as const;
+export type DeviceType = (typeof DeviceType)[keyof typeof DeviceType];
+
+@Entity('site_banners')
+export class SiteBanner {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', name: 'site_id' })
+  siteId: string;
+
+  @ManyToOne(() => Site, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'site_id' })
+  site: Site;
+
+  @Column({ type: 'varchar', length: 500, name: 'image_url' })
+  imageUrl: string;
+
+  @Column({ type: 'varchar', length: 500, name: 'link_url', nullable: true })
+  linkUrl: string | null;
+
+  @Column({ type: 'boolean', name: 'open_in_new_tab', default: true })
+  openInNewTab: boolean;
+
+  @Column({ type: 'boolean', name: 'is_active', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'timestamptz', name: 'start_at', nullable: true })
+  startAt: Date | null;
+
+  @Column({ type: 'timestamptz', name: 'end_at', nullable: true })
+  endAt: Date | null;
+
+  @Column({ type: 'int', name: 'display_order', default: 0 })
+  displayOrder: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'alt_text', nullable: true })
+  altText: string | null;
+
+  @Column({ type: 'varchar', length: 20, name: 'device_type' })
+  deviceType: string;
+
+  @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/banner/public-banner.controller.ts
+++ b/src/banner/public-banner.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { BannerService } from './banner.service';
+import { PublicBannerResponseDto } from './dto';
+import { Public } from '../auth/decorators/public.decorator';
+import { BusinessException } from '../common/exception/business.exception';
+import { ErrorCode } from '../common/exception/error-code';
+
+@Controller('public/banners')
+@Public()
+export class PublicBannerController {
+  constructor(private readonly bannerService: BannerService) {}
+
+  /**
+   * GET /public/banners?siteSlug=xxx&deviceType=desktop
+   * 공개 배너 조회 (활성 상태 + 기간 내 배너만)
+   */
+  @Get()
+  async getActiveBanners(
+    @Query('siteSlug') siteSlug: string,
+    @Query('deviceType') deviceType: string,
+  ): Promise<PublicBannerResponseDto[]> {
+    if (!siteSlug) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.COMMON_BAD_REQUEST,
+        'siteSlug query parameter is required',
+      );
+    }
+
+    if (!deviceType) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.COMMON_BAD_REQUEST,
+        'deviceType query parameter is required',
+      );
+    }
+
+    if (!['desktop', 'mobile'].includes(deviceType)) {
+      throw BusinessException.fromErrorCode(
+        ErrorCode.COMMON_BAD_REQUEST,
+        'deviceType must be desktop or mobile',
+      );
+    }
+
+    const banners = await this.bannerService.findActiveBySlug(siteSlug, deviceType);
+    return banners.map((banner) => this.bannerService.toPublicBannerResponse(banner));
+  }
+}

--- a/src/common/exception/error-code.ts
+++ b/src/common/exception/error-code.ts
@@ -167,6 +167,23 @@ export const ErrorCode = {
     HttpStatus.BAD_REQUEST,
     'Cannot delete category with existing posts',
   ),
+
+  // 배너 관련 에러
+  BANNER_NOT_FOUND: new ErrorCodeDefinition(
+    'BANNER_001',
+    HttpStatus.NOT_FOUND,
+    '배너를 찾을 수 없습니다',
+  ),
+  BANNER_LIMIT_EXCEEDED: new ErrorCodeDefinition(
+    'BANNER_002',
+    HttpStatus.BAD_REQUEST,
+    '배너는 최대 5개까지 등록할 수 있습니다',
+  ),
+  BANNER_INVALID_LINK: new ErrorCodeDefinition(
+    'BANNER_003',
+    HttpStatus.BAD_REQUEST,
+    '유효하지 않은 링크 URL입니다',
+  ),
 } as const;
 
 /**

--- a/src/database/migrations/1737600000000-AddSiteBannersTable.ts
+++ b/src/database/migrations/1737600000000-AddSiteBannersTable.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSiteBannersTable1737600000000 implements MigrationInterface {
+  name = 'AddSiteBannersTable1737600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // site_banners 테이블 생성
+    await queryRunner.query(`
+      CREATE TABLE "site_banners" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "site_id" uuid NOT NULL,
+        "image_url" character varying(500) NOT NULL,
+        "link_url" character varying(500),
+        "open_in_new_tab" boolean NOT NULL DEFAULT true,
+        "is_active" boolean NOT NULL DEFAULT true,
+        "start_at" TIMESTAMP WITH TIME ZONE,
+        "end_at" TIMESTAMP WITH TIME ZONE,
+        "display_order" integer NOT NULL DEFAULT 0,
+        "alt_text" character varying(255),
+        "device_type" character varying(20) NOT NULL,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_site_banners" PRIMARY KEY ("id")
+      )
+    `);
+
+    // site_id 인덱스 생성
+    await queryRunner.query(`
+      CREATE INDEX "IDX_site_banners_site_id" ON "site_banners" ("site_id")
+    `);
+
+    // (site_id, device_type) 복합 인덱스 생성
+    await queryRunner.query(`
+      CREATE INDEX "IDX_site_banners_site_device" ON "site_banners" ("site_id", "device_type")
+    `);
+
+    // site_id 외래키 제약조건 추가
+    await queryRunner.query(`
+      ALTER TABLE "site_banners"
+      ADD CONSTRAINT "FK_site_banners_site"
+      FOREIGN KEY ("site_id")
+      REFERENCES "sites"("id")
+      ON DELETE CASCADE
+      ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 외래키 제약조건 제거
+    await queryRunner.query(`
+      ALTER TABLE "site_banners"
+      DROP CONSTRAINT "FK_site_banners_site"
+    `);
+
+    // 인덱스 제거
+    await queryRunner.query(`
+      DROP INDEX "IDX_site_banners_site_device"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "IDX_site_banners_site_id"
+    `);
+
+    // 테이블 제거
+    await queryRunner.query(`
+      DROP TABLE "site_banners"
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
- site_banners 테이블 마이그레이션 추가
- SiteBanner Entity 및 DeviceType const 정의
- BannerService 구현 (CRUD + 순서 변경 + Public 조회)
- Admin API: presign, create, list, detail, update, delete, order
- Public API: 활성 배너 조회 (siteSlug + deviceType)
- ErrorCode 추가 (BANNER_NOT_FOUND, BANNER_LIMIT_EXCEEDED, BANNER_INVALID_LINK)

## Related Issue
Closes #29

## Test Plan
- [ ] 배너 생성 API 테스트 (최대 5개 제한 확인)
- [ ] 배너 목록 조회 테스트 (deviceType 필터)
- [ ] 배너 수정/삭제 API 테스트
- [ ] 순서 변경 API 테스트
- [ ] Public API 필터링 테스트 (활성/기간 조건)
- [ ] Presign URL 발급 테스트

## Changes
- `src/banner/` - 배너 모듈 (Entity, Service, Controllers, DTOs)
- `src/database/migrations/1737600000000-AddSiteBannersTable.ts` - 마이그레이션
- `src/common/exception/error-code.ts` - ErrorCode 추가
- `src/app.module.ts` - BannerModule 등록