### PR TITLE
feat(indexing): 로컬 JSON 파일 / 상용 Secrets Manager JSON 인증

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ lerna-debug.log*
 .env
 .env.*
 
+# Google 서비스 계정 키 (로컬 인덱싱 API용)
+google-service-account.json
+
 # temp directory
 .temp
 .tmp

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -66,8 +66,9 @@ import { JoiMsString } from 'src/common/utils/validation/joi-ms-string';
         // SuperAdmin
         SUPERADMIN_USER_IDS: Joi.string().optional().default(''),
 
-        // Google Indexing API
+        // Google Indexing API (로컬: 파일 경로, 상용: AWS Secrets Manager JSON)
         GOOGLE_SERVICE_ACCOUNT_CREDENTIALS: Joi.string().optional(),
+        GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_FILE: Joi.string().optional(),
       }),
     }),
   ],


### PR DESCRIPTION
## 변경 사항
- **로컬**: `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_FILE`로 서비스 계정 JSON 파일 경로 지정
- **상용**: `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`에 AWS Secrets Manager에서 가져온 JSON 원문 사용 (base64 제거)
- `google-service-account.json` .gitignore 추가 (키 파일 커밋 방지)

Made with [Cursor](https://cursor.com)